### PR TITLE
hotfix: fix displaying deleted groups

### DIFF
--- a/src/pickers/TaskGroupPicker.js
+++ b/src/pickers/TaskGroupPicker.js
@@ -29,7 +29,7 @@ function TaskGroupPicker(props) {
   const { isLoading, data, error } = useGraphqlQuery(
     `
       query TaskGroupPicker ($search: String) {
-          taskGroup(search: $search, first: 20) {
+          taskGroup(search: $search, first: 20, isDeleted: false) {
               edges {
                   node {
                       id


### PR DESCRIPTION
This PR fixes displaying deleted task groups in picker.