### PR TITLE
Fix mismatched dialog text for task approval/failure

### DIFF
--- a/src/components/TaskApprovementPanel.js
+++ b/src/components/TaskApprovementPanel.js
@@ -87,15 +87,15 @@ function TaskApprovementPanel({
     return () => confirmed && clearConfirm(false);
   }, [confirmed]);
 
-  const openResolveTaskConfirmDialog = () => coreConfirm(
+  const openResolveTaskConfirmDialog = (choiceString) => coreConfirm(
     formatMessage('task.resolve.confirm.title'),
-    approveOrFail === APPROVED ? formatMessage('task.resolve.confirm.fail.message')
-      : formatMessage('task.resolve.confirm.approve.message'),
+    choiceString === APPROVED ? formatMessage('task.resolve.confirm.approve.message')
+      : formatMessage('task.resolve.confirm.fail.message'),
   );
 
   const handleButtonClick = (choiceString) => {
     if (task?.id && user?.id) {
-      openResolveTaskConfirmDialog(approveOrFail);
+      openResolveTaskConfirmDialog(choiceString);
       setApproveOrFail(choiceString);
     }
   };


### PR DESCRIPTION
Previously the tasks dialog was showing 'approve' or 'fail' in its message in a way that did not fully reflect which button had been pressed


https://github.com/user-attachments/assets/12c016cb-f2b1-45f1-9100-6901adcebb9e

I've made small fixes so that this should always display correctly now


https://github.com/user-attachments/assets/f40ef30d-ad9e-4c40-bc3d-a978c7eb3379

