### PR TITLE
Allow everyone to view more usable "All Tasks" menu

### DIFF
--- a/src/menus/TasksMainMenu.js
+++ b/src/menus/TasksMainMenu.js
@@ -16,15 +16,9 @@ function TasksMainMenu(props) {
   const rights = useSelector((store) => store.core?.user?.i_user?.rights ?? []);
   const entries = [
     {
-      text: formatMessage(props.intl, 'tasksManagement', 'entries.tasksManagementView'),
-      icon: <AssignmentIcon />,
-      route: '/tasks',
-    },
-    {
       text: formatMessage(props.intl, 'tasksManagement', 'entries.tasksManagementAllView'),
       icon: <AssignmentIcon />,
       route: '/AllTasks',
-      filter: (rights) => rights.includes(RIGHT_TASKS_MANAGEMENT_SEARCH_ALL),
     },
   ];
   entries.push(


### PR DESCRIPTION
Currently "All Tasks" is only visible to super users or selected roles, but it's way more usable than the "Task" view. Make "All Tasks" visible to all users. Also, remove the "Tasks" view as it is not user-friendly and is very less likely to be used. 