### PR TITLE
OSB-56: fixing store reference in tasks management

### DIFF
--- a/src/components/TaskApprovementPanel.js
+++ b/src/components/TaskApprovementPanel.js
@@ -145,8 +145,8 @@ const mapStateToProps = (state) => ({
   rights: !!state.core && !!state.core.user && !!state.core.user.i_user ? state.core.user.i_user.rights : [],
   user: !!state.core && !!state.core.user ? state.core.user : null,
   confirmed: state.core.confirmed,
-  submittingMutation: state.socialProtection.submittingMutation,
-  mutation: state.socialProtection.mutation,
+  submittingMutation: state.tasksManagement.submittingMutation,
+  mutation: state.tasksManagement.mutation,
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({


### PR DESCRIPTION
Fixing wrong reference in state/store in tasks management module. It was 'socialProtection', should be 'tasksManagement'