### PR TITLE
fix(OP-3095): correctly pass task object to contributed confirmation …

### DIFF
--- a/src/components/TaskApprovementPanel.jsx
+++ b/src/components/TaskApprovementPanel.jsx
@@ -115,7 +115,7 @@ function TaskApprovementPanel({
     if (contrib?.confirmationPanel) {
       return (
         <contrib.confirmationPanel
-          task
+          task={task}
           defaultAction={handleButtonClick}
           defaultDisabled={disable}
         />


### PR DESCRIPTION
…panels

#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

The Error: <contrib.confirmationPanel task ... />

**Why it failed**: This was a prop-passing typo. In React, writing task as a prop without an assignment is the same as task={true}. The confirmation panels (like the one used for Claim Sampling) were expecting the actual Task Object, but instead received the boolean value true. This caused the confirmation dialogs to be empty or fail when they tried to read task.id.
# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
